### PR TITLE
upgrade to xunit 2.3.1 and xbehave 2.3.0-rc0001-build717

### DIFF
--- a/samples/Brickweave.Samples.WebApp.Tests/Brickweave.Samples.WebApp.Tests.csproj
+++ b/samples/Brickweave.Samples.WebApp.Tests/Brickweave.Samples.WebApp.Tests.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Xbehave" Version="2.2.0-beta0003-build685" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Xbehave" Version="2.3.0-rc0001-build717" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.Cqrs.Cli.Tests/Brickweave.Cqrs.Cli.Tests.csproj
+++ b/tests/Brickweave.Cqrs.Cli.Tests/Brickweave.Cqrs.Cli.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NodaTime" Version="2.2.2" />
     <PackageReference Include="NSubstitute" Version="3.0.1" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.Cqrs.Tests/Brickweave.Cqrs.Tests.csproj
+++ b/tests/Brickweave.Cqrs.Tests/Brickweave.Cqrs.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NSubstitute" Version="3.0.1" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.Domain.Tests/Brickweave.Domain.Tests.csproj
+++ b/tests/Brickweave.Domain.Tests/Brickweave.Domain.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NSubstitute" Version="3.0.1" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.EventStore.SqlServer.Tests/Brickweave.EventStore.SqlServer.Tests.csproj
+++ b/tests/Brickweave.EventStore.SqlServer.Tests/Brickweave.EventStore.SqlServer.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.EventStore.Tests/Brickweave.EventStore.Tests.csproj
+++ b/tests/Brickweave.EventStore.Tests/Brickweave.EventStore.Tests.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.Messaging.ServiceBus.Tests/Brickweave.Messaging.ServiceBus.Tests.csproj
+++ b/tests/Brickweave.Messaging.ServiceBus.Tests/Brickweave.Messaging.ServiceBus.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Brickweave.Messaging.Tests/Brickweave.Messaging.Tests.csproj
+++ b/tests/Brickweave.Messaging.Tests/Brickweave.Messaging.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some background: before releasing xbehave 2.3.0 RTM, I'm attempting to find projects who would be willing to test the release candidate. This PR upgrades xbehave to 2.3.0-rc0001 (which also requires an upgrade to the latest xunit, which is 2.3.1).

Note that an xbehave RC is a _true RC_. I.e. it is RTM quality and if no bugs are found, 2.3.0 RTM will be released with a build from the same source code as the latest 2.3.0 RC. Therefore the risk of using an RC (which is, after all, still a pre-release) should be very low, but of course, it's up to you whether you want to merge this PR. 😉

Regardless, thanks for using xbehave, I hope you're enjoying it. 👍 